### PR TITLE
fix to add_colormap, uses np.array[uint32]

### DIFF
--- a/bindings/imgui_bundle/implot/__init__.pyi
+++ b/bindings/imgui_bundle/implot/__init__.pyi
@@ -2441,6 +2441,19 @@ def show_demo_window(p_open: Optional[bool] = None) -> Optional[bool]:
 # MANUAL BINDINGS BELOW
 ###############################################################################
 
+# Add a new colormap. The color data will be copied. The colormap can be used by pushing either the returned index or the
+# string name with PushColormap. The colormap name must be unique and the size must be greater than 1. You will receive
+# an assert otherwise! By default, colormaps are considered to be qualitative (i.e. discrete). If you want to create a
+# continuous colormap, set #qual=False. This will treat the colors you provide as keys, and ImPlot will build a linearly
+# interpolated lookup table. The memory footprint of this table will be exactly ((size-1)*255+1)*4 bytes.
+#
+# Warning:
+# - the colormap `cols` must be a numpy array with 4 columns (RGBA), and as many lines as colors.
+# - its dtype must be either "np.uint32" (if using hexadecimal colors), or "float" (if using float values between 0 and 1)
+def add_colormap(name: str, cols: np.ndarray, qual: bool = True) -> Colormap:
+    pass
+
+
 # Sets an axis' ticks and optionally the labels for the next plot. To keep the default ticks, set #keep_default=true.
 # IMPLOT_API void SetupAxisTicks(ImAxis axis, const double* values, int n_ticks, const char* const labels[]=NULL, bool keep_default=false);    /* original C++ signature */
 def setup_axis_ticks(axis: ImAxis, v_min: float, v_max: float, n_ticks: int, labels: List[str], keep_default: bool = False):

--- a/bindings/imgui_bundle/implot/__init__.pyi
+++ b/bindings/imgui_bundle/implot/__init__.pyi
@@ -2232,13 +2232,6 @@ def get_marker_name(idx: Marker) -> str:
 # an assert otherwise! By default colormaps are considered to be qualitative (i.e. discrete). If you want to create a
 # continuous colormap, set #qual=False. This will treat the colors you provide as keys, and ImPlot will build a linearly
 # interpolated lookup table. The memory footprint of this table will be exactly ((size-1)*255+1)*4 bytes.
-# IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImVec4* cols, int size, bool qual=true);    /* original C++ signature */
-def add_colormap(name: str, cols: ImVec4, size: int, qual: bool = True) -> Colormap:
-    pass
-
-# IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImU32*  cols, int size, bool qual=true);    /* original C++ signature */
-def add_colormap(name: str, cols: ImU32, size: int, qual: bool = True) -> Colormap:
-    pass
 
 # IMPLOT_API int GetColormapCount();    /* original C++ signature */
 def get_colormap_count() -> int:

--- a/external/implot/bindings/litgen_options_implot.py
+++ b/external/implot/bindings/litgen_options_implot.py
@@ -81,6 +81,10 @@ def litgen_options_implot() -> LitgenOptions:
             # void PlotPieChart(const char* const label_ids[], const T* values, int count, double x, double y, double radius, bool normalize=false, const char* label_fmt="%.1f", double angle0=90);
             #                                         ^                               ^
             "PlotPieChart",
+
+            # IMPLOT_API ImPlotColormap AddColormap(const char* name, const ImU32*  cols, int size, bool qual=true);
+            # (This API is a bit exotic, and cannot be bound automatically)
+            "^AddColormap$"
         ]
     )
 

--- a/external/implot/bindings/pybind_implot.cpp
+++ b/external/implot/bindings/pybind_implot.cpp
@@ -2285,6 +2285,17 @@ void py_init_module_implot(py::module& m)
     // MANUAL BINDINGS BELOW
     ///////////////////////////////////////////////////////////////////////////
 
+    // Add a new colormap, inputs are np.array[uint32]
+    m.def("add_colormap",
+        [](const char * name, const py::array & cols, int size, bool qual=true)
+        {
+            const void * values_from_pyarray = cols.data();            
+            return ImPlot::AddColormap(name, static_cast<const uint32_t *>(values_from_pyarray),size, qual);
+
+        }, py::arg("name"), py::arg("cols"), py::arg("size"), py::arg("qual") = true,
+        "Add a new colormap."
+        );
+
     // SetupAxisTicks, cf https://github.com/pthom/imgui_bundle/issues/81
     m.def("setup_axis_ticks",
           [](ImAxis axis, double v_min, double v_max, int n_ticks, const std::vector<std::string>& labels, bool keep_default=false)

--- a/external/implot/bindings/pybind_implot.cpp
+++ b/external/implot/bindings/pybind_implot.cpp
@@ -2096,12 +2096,6 @@ void py_init_module_implot(py::module& m)
         "Returns the null terminated string name for an ImPlotMarker.",
         pybind11::return_value_policy::reference);
 
-    m.def("add_colormap",
-        py::overload_cast<const char *, const ImVec4 *, int, bool>(ImPlot::AddColormap), py::arg("name"), py::arg("cols"), py::arg("size"), py::arg("qual") = true);
-
-    m.def("add_colormap",
-        py::overload_cast<const char *, const ImU32 *, int, bool>(ImPlot::AddColormap), py::arg("name"), py::arg("cols"), py::arg("size"), py::arg("qual") = true);
-
     m.def("get_colormap_count",
         ImPlot::GetColormapCount, "Returns the number of available colormaps (i.e. the built-in + user-added count).");
 


### PR DESCRIPTION
Amended add_colormap to take a numpy array of type uint32.

I was having trouble where implot.plot_heatmap was really eating at my CPU.  Reading into it, the issue has been resolved (see the implot backend branch), but I wanted to take it even further by only rendering the plot when needed.  To do that I needed my colorbar to match exactly.

Here is an example usage using a Matplotlib colormap and implot.plot_image:


```python
from imgui_bundle import imgui, immapp, implot
from OpenGL import GL
import matplotlib as mpl
import numpy as np

image_dirty = True
tex_id = None
cmap_name = 'turbo'
vmin=-0.2
vmax=1.0

def gui():
    global image_dirty
    global tex_id
    global cmap
    imgui.text("Hello, image heatmap!")

    if image_dirty:
        x = np.linspace(-4,4, 401)
        xx = np.outer(x,x)
        yy = np.sinc(xx)
        scalar_mappable = mpl.cm.ScalarMappable(None,cmap_name)
        scalar_mappable.set_clim(vmin,vmax)
        img_np = scalar_mappable.to_rgba(yy,bytes=True)
        
        tex_id = GL.glGenTextures(1)
        GL.glBindTexture(GL.GL_TEXTURE_2D, tex_id)
        GL.glTextureParameteri(tex_id, GL.GL_TEXTURE_MIN_FILTER, GL.GL_LINEAR)
        GL.glTextureParameteri(tex_id, GL.GL_TEXTURE_MAG_FILTER, GL.GL_LINEAR)
        GL.glTextureParameteri(tex_id, GL.GL_TEXTURE_WRAP_S, GL.GL_CLAMP_TO_BORDER)
        GL.glTextureParameteri(tex_id,GL.GL_TEXTURE_WRAP_T, GL.GL_CLAMP_TO_BORDER)
        GL.glTexImage2D(GL.GL_TEXTURE_2D, 0, GL.GL_RGBA, img_np.shape[0], img_np.shape[1],0,
                        GL.GL_RGBA, GL.GL_UNSIGNED_BYTE,img_np)
        image_dirty = False

    axis_flags = implot.AxisFlags_.no_initial_fit | implot.AxisFlags_.foreground #implot.AxisFlags_.lock | implot.AxisFlags_.no_grid_lines | implot.AxisFlags_.no_tick_marks

    implot.set_next_axes_limits(-4,4,-4,4)
    if implot.begin_plot("Sinc Function",[imgui.get_content_region_avail().x*.85,-1],implot.Flags_.no_legend | implot.Flags_.no_mouse_text):
        implot.setup_axes(None,None, axis_flags, axis_flags)
        implot.plot_image("##img_plot",tex_id, [-4,-4],[4,4])
        implot.end_plot()

    imgui.same_line()

    if implot.get_colormap_index(cmap_name) ==-1:
        colors= mpl.colors.to_rgba_array(mpl.colormaps[cmap_name].colors)*255
        colors_u32 = np.concatenate(colors.astype('uint8')).view('uint32')
        cmap = implot.add_colormap(cmap_name,colors_u32,len(colors_u32))

    implot.colormap_scale("##heatmap_scale",  vmin, vmax,imgui.ImVec2(-1,-1),"%g",0,cmap)

immapp.run(
    gui_function=gui,  # The Gui function to run
    window_title="Hello Image Heatmap",  # the window title
    window_size_auto=True,  # Auto size the application window given its widgets
    # Uncomment the next line to restore window position and size from previous run
    # window_restore_previous_geometry==True
    with_implot=True
)
```

and the result:
![image](https://user-images.githubusercontent.com/60329871/221232915-58db363a-0c4a-4e2c-ba17-7b1125a2f4b6.png)
