### PR TITLE
Explicitly set encoding to utf8 when open files for reading/writing

### DIFF
--- a/bindings/imgui_bundle/demos_python/demo_text_edit.py
+++ b/bindings/imgui_bundle/demos_python/demo_text_edit.py
@@ -7,7 +7,7 @@ TextEditor = ed.TextEditor
 
 
 def _prepare_text_editor():
-    with open(__file__) as f:
+    with open(__file__, encoding="utf8") as f:
         this_file_code = f.read()
     editor = TextEditor()
     editor.set_text(this_file_code)

--- a/bindings/imgui_bundle/demos_python/demo_utils/api_demos.py
+++ b/bindings/imgui_bundle/demos_python/demo_utils/api_demos.py
@@ -84,7 +84,7 @@ def show_markdown_file(doc_filename: str) -> None:
 def read_code(filename: str) -> str:
     if not os.path.isfile(filename):
         return ""
-    with open(filename) as f:
+    with open(filename, encoding="utf8") as f:
         r = f.read()
         return r
 

--- a/bindings/imgui_bundle/demos_python/demo_utils/demo_app_table.py
+++ b/bindings/imgui_bundle/demos_python/demo_utils/demo_app_table.py
@@ -9,7 +9,7 @@ from imgui_bundle import imgui, imgui_color_text_edit as text_edit, imgui_md, Im
 
 def _read_code(filepath: str) -> str:
     if os.path.isfile(filepath):
-        with open(filepath) as f:
+        with open(filepath, encoding="utf8") as f:
             code = f.read()
             return code
     else:

--- a/external/bindings_generation/add_copyright.py
+++ b/external/bindings_generation/add_copyright.py
@@ -94,14 +94,14 @@ def add_copyright(filename):
         comment_marker = extensionCommentMarkers[extension]
         copyright_comment = comment_marker + " " + copyright_str
 
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding="utf8") as f:
             content = f.read()
             lines = content.split("\n")
 
         if lines[0] != copyright_comment:
             lines = [copyright_comment] + lines
             content_with_copyright = "\n".join(lines)
-            with open(filename, "w") as f:
+            with open(filename, "w", encoding="utf8") as f:
                 f.write(content_with_copyright)
 
 

--- a/external/bindings_generation/autogenerate_all.py
+++ b/external/bindings_generation/autogenerate_all.py
@@ -39,7 +39,7 @@ _FILELIST_
     cmake_content = cmake_template.replace("_FILELIST_", filelist)
     this_dir = os.path.dirname(__file__)
     cmake_file = this_dir + "/cpp/all_pybind_files.cmake"
-    with open(cmake_file, "w") as f:
+    with open(cmake_file, "w", encoding="utf8") as f:
         f.write(cmake_content)
 
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ ROOT_PACKAGE_NAME = "imgui_bundle"
 
 
 def get_readme():
-    with open(ROOT_PACKAGE_FOLDER + "/Readme_pypi.md") as f:
+    with open(ROOT_PACKAGE_FOLDER + "/Readme_pypi.md", encoding="utf8") as f:
         r = f.read()
     return r
 


### PR DESCRIPTION
Related issue: https://github.com/pthom/hello_imgui/issues/49

I'm not sure if it's okay to add this. Merge at your discretion.

Other option is to let users setup env variable: `export PYTHONUTF8=1`.

P.S. I struggled to use `utf8` or `utf-8`, both seem to work.

References:

- https://stackoverflow.com/questions/66380829/utf8-encoding-issues-in-python-windows
- https://docs.python.org/3/using/windows.html#utf-8-mode