### PR TITLE
update docking demo to use nodeFlags

### DIFF
--- a/bindings/imgui_bundle/demos_cpp/demos_immapp/demo_docking.cpp
+++ b/bindings/imgui_bundle/demos_cpp/demos_immapp/demo_docking.cpp
@@ -13,6 +13,7 @@ It demonstrates:
 #include "hello_imgui/hello_imgui.h"
 #include "hello_imgui/icons_font_awesome.h"
 #include "imgui.h"
+#include "imgui_internal.h"
 #include "imgui_md_wrapper/imgui_md_wrapper.h"
 #include "immapp/immapp.h"
 #include "immapp/clock.h"
@@ -237,6 +238,7 @@ int main(int, char**)
     splitMainLeft.newDock = "LeftSpace";
     splitMainLeft.direction = ImGuiDir_Left;
     splitMainLeft.ratio = 0.25f;
+    splitMainLeft.nodeFlags = ImGuiDockNodeFlags_NoTabBar;
 
     // Finally, transmit these splits to HelloImGui
     runnerParams.dockingParams.dockingSplits = {splitMainBottom, splitMainLeft};


### PR DESCRIPTION
This add the node flags. Most of the patch is in the attached below file since else it gets a little hard to send given thats on a different repo. You should be able to git apply that to hello_imgui

[0001-add-support-for-setting-node-flags-of-new-dock-space.patch](https://github.com/pthom/imgui_bundle/files/10930253/0001-add-support-for-setting-node-flags-of-new-dock-space.patch)
