### PR TITLE
Fixed Shellapi.h not found when cross-compiling

### DIFF
--- a/external/immapp/immapp/browse_to_url.cpp
+++ b/external/immapp/immapp/browse_to_url.cpp
@@ -5,7 +5,7 @@
 #include <emscripten.h>
 #elif defined(_WIN32)
 #include <windows.h>
-#include <Shellapi.h>
+#include <shellapi.h>
 #elif defined(__APPLE__)
 #include <TargetConditionals.h>
 #endif


### PR DESCRIPTION
If you cross-compile for Windows on Linux using mingw64 it shows this error message:
```
[400%] Building CXX object _deps/imgui_bundle-build/external/immapp/immapp/CMakeFiles/immapp.dir/browse_to_url.cpp.obj
/home/golas/Repos/use/build/_deps/imgui_bundle-src/external/immapp/immapp/browse_to_url.cpp:8:10: fatal error: Shellapi.h: No such file or directory
    8 | #include <Shellapi.h>
      |          ^~~~~~~~~~~~
```

This was apparently caused by the mingw64 not liking the uppercase `Shellapi.h` variant, but it works on Windows for both lowercase and uppercase. There was a similar issue in some other project: https://github.com/surge-synthesizer/surge-rack/issues/218

This PR fixes the problem by changing it to `shellapi.h`.