### PR TITLE
Update bindings_intro with updated steps

### DIFF
--- a/devel_docs/devdoc_parts/bindings_intro.adoc
+++ b/devel_docs/devdoc_parts/bindings_intro.adoc
@@ -7,20 +7,17 @@ The generator in itself is located in link:https://github.com/pthom/litgen/tree/
 
 ==== Installing the generator
 
-**Step 1: install srcML**
-
-Get and install srcML from its link:http://www.srcml.org/#download[official site].
-
-**Step 2: install the generator and the required libraries**
+**Step 1: install the generator and the required libraries**
 
 You will need to install the following python packages (see requirements-dev.txt):
 
 ----
-litgen @ git+https://github.com/pthom/litgen
 black
+litgen @ git+https://github.com/pthom/litgen
 mypy
-pytest
 opencv-contrib-python
+pybind11
+pytest
 ----
 
 ==== Quick information about the generator


### PR DESCRIPTION
I installed a clean `venv`:
```
py -m venv venv
venv\Scripts\activate.bat
pip install -r requirements-dev.txtp
```

And with this, I could run `external\imgui_md\bindings\generate_imgui_md.py`.
The step of installing `srcML` does not seem to be needed anymore.