### PR TITLE
update manual pybind function name for imgui backends

### DIFF
--- a/external/imgui/bindings/pybind_imgui_backends.cpp
+++ b/external/imgui/bindings/pybind_imgui_backends.cpp
@@ -108,7 +108,7 @@ void py_init_module_imgui_backends(py::module& m)
               return ImGui_ImplGlfw_RestoreCallbacks((GLFWwindow*)window_address);
           }, py::arg("window_address"));
 
-    m.def("glfw_restore_callbacks",
+    m.def("glfw_window_focus_callback",
           [](size_t window_address, int focused) {
               return ImGui_ImplGlfw_WindowFocusCallback((GLFWwindow*)window_address, focused);
           }, py::arg("window_address"), py::arg("focused"));


### PR DESCRIPTION
Update pybind11 function name:
 
Define `ImGui_ImplGlfw_WindowFocusCallback` to `glfw_window_focus_callback`.