### PR TITLE
MacOS binary wheel installation

### DIFF
--- a/.github/workflows/cpp_lib.yml
+++ b/.github/workflows/cpp_lib.yml
@@ -7,7 +7,7 @@ on:
   push:
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: "10.15"
+  MACOSX_DEPLOYMENT_TARGET: "11.0"
 
 jobs:
   build:

--- a/.github/workflows/cpp_lib_with_bindings.yml
+++ b/.github/workflows/cpp_lib_with_bindings.yml
@@ -7,7 +7,7 @@ on:
   push:
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: "10.15"
+  MACOSX_DEPLOYMENT_TARGET: "11.0"
 
 jobs:
   build:

--- a/.github/workflows/pip.yml
+++ b/.github/workflows/pip.yml
@@ -6,7 +6,7 @@ on:
   push:
 
 env:
-  MACOSX_DEPLOYMENT_TARGET: "10.15"
+  MACOSX_DEPLOYMENT_TARGET: "11.0"
   DISPLAY: ":0"
 
 jobs:

--- a/bindings/imgui_bundle/doc/Readme.adoc
+++ b/bindings/imgui_bundle/doc/Readme.adoc
@@ -331,8 +331,10 @@ A big thank you to their authors for their awesome work!
 ----
 pip install imgui-bundle
 pip install opencv-contrib-python # <1>
+pip install pyGLM # <2>
 ----
 <1> in order to run the immvision module, install opencv-python or opencv-contrib-python (NB: the headless versions of these packages, such as opencv-python-headless, also work)
+<2> in order to run the demo, install pyGLM
 
 Note: under windows, you might need to install https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2015-2017-2019-and-2022[msvc redist].
 

--- a/bindings/imgui_bundle/doc/Readme.adoc
+++ b/bindings/imgui_bundle/doc/Readme.adoc
@@ -338,6 +338,8 @@ pip install pyGLM # <2>
 
 Note: under windows, you might need to install https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2015-2017-2019-and-2022[msvc redist].
 
+Note: under MacOS, you may run into problems where the binary wheel is not used and pip will try to compile the source distribution. This will fail if you do not have XCode installed and set up. Issue the command `SYSTEM_VERSION_COMPAT=0 pip install --only-binary=:all: imgui_bundle` as a workaround.
+
 === Install from source:
 [source, bash]
 ----

--- a/bindings/imgui_bundle/doc/Readme.adoc
+++ b/bindings/imgui_bundle/doc/Readme.adoc
@@ -332,7 +332,7 @@ A big thank you to their authors for their awesome work!
 pip install imgui-bundle
 pip install opencv-contrib-python # <1>
 ----
-<1> in order to run the immvision module, install opencv-python or opencv-contrib-python
+<1> in order to run the immvision module, install opencv-python or opencv-contrib-python (NB: the headless versions of these packages, such as opencv-python-headless, also work)
 
 Note: under windows, you might need to install https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170#visual-studio-2015-2017-2019-and-2022[msvc redist].
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -80,7 +80,7 @@ before-build = "uname -a"
 test-skip = ["*"]
 # Environment variables
 # IMGUIBUNDLE_OPENCV_FETCH_SOURCE => Will fetch, build and install a very-minimalist OpenCV
-environment = { MACOSX_DEPLOYMENT_TARGET="10.15" }
+environment = { MACOSX_DEPLOYMENT_TARGET="11.0" }
 
 # Architectures
 # -------------


### PR DESCRIPTION
As per #215 (see also #80), document workaround if binary wheel for MacOS is not picked up by pip.
Also reverts `MACOSX_DEPLOYMENT_TARGET` to 11.0