### PR TITLE
No need to link to nlohmann_json -- header only

### DIFF
--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -52,8 +52,6 @@ if(HELLOIMGUI_HAS_OPENGL AND NOT IMGUI_BUNDLE_DISABLE_IMMVISION)
     set(IMMVISION_SERIALIZE_JSON ON CACHE INTERNAL "" FORCE)
     add_subdirectory(immvision)
     if (IMGUI_BUNDLE_WITH_IMMVISION)
-        target_link_libraries(immvision PUBLIC nlohmann_json)
-
         target_link_libraries(imgui_bundle INTERFACE immvision)
         hello_imgui_msvc_target_group_sources(immvision)
         target_compile_definitions(imgui_bundle INTERFACE IMGUI_BUNDLE_WITH_IMMVISION)


### PR DESCRIPTION
In using the system's nlohmann json library I ran into compilation errors that the library could not be linked to since `-lnlohmann` could not be found

I believe that nlohmann_json is a header only so it should be fine to remove this in all cases.

This fixed my usecase