### PR TITLE
Fix matplotlib example due to use of a deprecated function

### DIFF
--- a/bindings/imgui_bundle/imgui_fig.py
+++ b/bindings/imgui_bundle/imgui_fig.py
@@ -53,10 +53,10 @@ def _fig_to_image(label_id: str, figure: "matplotlib.figure.Figure", refresh_ima
         figure.canvas.draw()
         # Get the RGBA buffer from the figure
         w, h = figure.canvas.get_width_height()
-        buf = numpy.fromstring(figure.canvas.tostring_rgb(), dtype=numpy.uint8)  # type: ignore
+        buf = numpy.frombuffer(figure.canvas.buffer_rgba(), dtype=numpy.uint8)  # type: ignore
 
         try:
-            buf.shape = (h, w, 3)
+            buf.shape = (h, w, 4)
             img = buf
             matplotlib.pyplot.close(figure)
             statics.fig_image_cache[fig_id] = img


### PR DESCRIPTION
Removes the use of the function `tostring_rgb` which was deprecated in [matplotlib version 3.8](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.8.0.html#rendereragg-tostring-rgb-and-figurecanvasagg-tostring-rgb), and removed recently in [version 3.10](https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.10.0.html#rendereragg-tostring-rgb-and-figurecanvasagg-tostring-rgb).

Previous error:
```
File ".../lib/python3.13/site-packages/imgui_bundle/demos_python/demos_immapp/demo_matplotlib.py", line 60, in gui
    imgui_fig.fig("Animated figure", animated_figure.fig, refresh_image=True, show_options_button=False)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File ".../lib/python3.13/site-packages/imgui_bundle/imgui_fig.py", line 102, in fig
    image_rgb = _fig_to_image(label_id, figure, refresh_image)
  File ".../lib/python3.13/site-packages/imgui_bundle/imgui_fig.py", line 56, in _fig_to_image
    buf = numpy.fromstring(figure.canvas.tostring_rgb(), dtype=numpy.uint8)  # type: ignore
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'FigureCanvasAgg' object has no attribute 'tostring_rgb'. Did you mean: 'tostring_argb'?
```
