### PR TITLE
Browse code using ImGuiColorTextEdit code editor

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,7 @@
 [submodule "external/imgui/imgui"]
 	path = external/imgui/imgui
-	url = https://github.com/pthom/imgui.git
-	branch = imgui_bundle
+	url = https://github.com/uzoochogu/imgui.git
+	branch = browse-code-with-ImGuiColorTextEdit
 [submodule "external/glfw/glfw"]
 	path = external/glfw/glfw
 	url = https://github.com/glfw/glfw.git
@@ -40,8 +40,8 @@
 	branch = master
 [submodule "external/ImGuiColorTextEdit/ImGuiColorTextEdit"]
 	path = external/ImGuiColorTextEdit/ImGuiColorTextEdit
-	url = https://github.com/pthom/ImGuiColorTextEdit.git
-	branch = imgui_bundle
+	url = https://github.com/uzoochogu/ImGuiColorTextEdit.git
+	branch = disable-auto-scroll-up-on-text-set
 [submodule "external/ImGuizmo/ImGuizmo"]
 	path = external/ImGuizmo/ImGuizmo
 	url = https://github.com/pthom/ImGuizmo.git

--- a/bindings/imgui_bundle/demos_cpp/CMakeLists.txt
+++ b/bindings/imgui_bundle/demos_cpp/CMakeLists.txt
@@ -37,7 +37,7 @@ if (EMSCRIPTEN)
     target_link_options(demo_imgui_bundle PRIVATE "SHELL:--preload-file ${python_backends_folder}@/python_backends")
 endif()
 
-
+target_compile_definitions(your_target PRIVATE INSIDE_IMGUI_BUNDLE)
 target_link_libraries(demo_imguizmo_launcher PRIVATE demos_imguizmo)
 target_link_libraries(demo_node_editor_launcher PRIVATE demos_node_editor)
 target_link_libraries(demo_tex_inspect_launcher PRIVATE demos_tex_inspect)


### PR DESCRIPTION
This pull request allow imgui code browsing using `ImGuiColorTextEdit` when used as a submodule in the `imgui_bundle` project.

* Point branch to forks as Proof of Concept
* Uses compile options to set defines in relevant file to trigger compilation of `ImGuiColorTextEdit` editor code in `imgui_demo.cpp`.

Changes are proposed in the following projects to enable this feature:
1. pthom/imgui_bundle - `main` branch - (This PR)
2. pthom/imgui - `imgui_bundle` branch - [Link to PR](https://github.com/pthom/imgui/pull/1)
3. pthom/ImGuiColorTextEdit - `imgui_bundle` branch - [Link to PR](https://github.com/pthom/ImGuiColorTextEdit/pull/3)

Note that submodules were changed to point to forks since they have the relevant changes. 
And can be changed back to your forks if they are merged.

![image](https://github.com/user-attachments/assets/4d304aa8-5fa1-4765-abaf-658e1f122c46)


