### PR TITLE
fix: exclude `MkTime` from implot_internal stubs

### DIFF
--- a/bindings/imgui_bundle/implot/internal.pyi
+++ b/bindings/imgui_bundle/implot/internal.pyi
@@ -2234,15 +2234,6 @@ def get_days_in_month(year: int, month: int) -> int:
 # NB: The following functions only work if there is a current ImPlotContext because the
 # internal tm struct is owned by the context! They are aware of ImPlotStyle.UseLocalTime.
 
-# static inline ImPlotTime MkTime(struct tm *ptm) {    /* original C++ signature */
-#     if (GetStyle().UseLocalTime) return MkLocTime(ptm);
-#     else                         return MkGmtTime(ptm);
-# }
-def mk_time(ptm: struct tm) -> Time:
-    """ // Make a UNIX timestamp from a tm struct according to the current ImPlotStyle.UseLocalTime setting.
-    (private API)
-    """
-    pass
 # static inline tm* GetTime(const ImPlotTime& t, tm* ptm) {    /* original C++ signature */
 #     if (GetStyle().UseLocalTime) return GetLocTime(t,ptm);
 #     else                         return GetGmtTime(t,ptm);

--- a/external/implot/bindings/generate_implot.py
+++ b/external/implot/bindings/generate_implot.py
@@ -51,6 +51,7 @@ def autogenerate_implot_internal() -> None:
             "^FormatDateTime$",
             "^FormatTime$",
             "^LabelAxisValue$",
+            "^MkTime$",
             "^MkGmtTime$",
             "^GetGmtTime$",
             "^MkLocTime$",

--- a/external/implot/bindings/pybind_implot_internal.cpp
+++ b/external/implot/bindings/pybind_implot_internal.cpp
@@ -1326,11 +1326,6 @@ void py_init_module_implot_internal(nb::module_& m)
         nb::arg("year"), nb::arg("month"),
         " Returns the number of days in a month, accounting for Feb. leap years. #month is zero indexed.\n(private API)");
 
-    m.def("mk_time",
-        ImPlot::MkTime,
-        nb::arg("ptm"),
-        " // Make a UNIX timestamp from a tm struct according to the current ImPlotStyle.UseLocalTime setting.\n(private API)");
-
     m.def("get_time",
         ImPlot::GetTime,
         nb::arg("t"), nb::arg("ptm"),


### PR DESCRIPTION
fixes #348 

@pthom, this is the bare minimum (and can confirm it works to allow type checking externally again).  Let me know if i should be generating and checking in the updated stubs as well (I supposed CI will likely tell me too)